### PR TITLE
Update link to GDS way for git URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,4 +6,4 @@ Please read [the `ministryofjustice` CODE_OF_CONDUCT.md](https://github.com/mini
 
 ## Commit hygiene
 
-Please see the [GDS Git style guide in the 'How to store source code' page of the GDS Way](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages), which describes how we prefer Git history and commit messages to read.
+Please see the [GDS Git style guide for 'Working with Git' page of the GDS Way](https://gds-way.cloudapps.digital/standards/source-code/working-with-git.html#commit-messages), which describes how we prefer Git history and commit messages to read.


### PR DESCRIPTION
- The link to the GDS way for `working with git` has changed, this pr updates that url.