### PR TITLE
:copilot: Enable OpenAI GPT 5.4

### DIFF
--- a/docs/decisions/0001-enterprise-level-copilot-settings.md
+++ b/docs/decisions/0001-enterprise-level-copilot-settings.md
@@ -1,7 +1,7 @@
 # 1. Initial configuration of enterprise level copilot settings
 
 Date: 2025-09-12
-Last Updated: 2026-02-20
+Last Updated: 2026-03-06
 
 ## Status
 
@@ -49,7 +49,7 @@ No pattern currently set
 | Anthropic Claude Opus 4.6 (fast mode) | Let organisations decide | Enabled                                  |
 | Google Gemini 2.5 Pro                 | Let organisations decide | Enabled                                  |
 | Google Gemini 3 Pro (Preview)         | Let organisations decide | Enabled                                  |
-| Google Gemini 3.1 Pro (Preview)       | Let organisations decide | Enabled                                  |
+| Google Gemini 3.1 Pro                 | Let organisations decide | Enabled                                  |
 | Google Gemini 3 Flash (Preview)       | Let organisations decide | Enabled                                  |
 | OpenAI GPT-5                          | Let organisations decide | Enabled                                  |
 | OpenAI GPT-5-Codex (Preview)          | Let organisations decide | Enabled                                  |
@@ -61,6 +61,7 @@ No pattern currently set
 | OpenAI GPT-5.2                        | Let organisations decide | Enabled                                  |
 | OpenAI GPT-5.2-Codex                  | Let organisations decide | Enabled                                  |
 | OpenAI GPT-5.3-Codex                  | Let organisations decide | Enabled                                  |
+| OpenAI GPT-5.4                        | Let organisations decide | Enabled                                  |
 | xAI Grok Code Fast 1                  | Disabled everywhere      | Disabled by Enterprise                   |
 
 ### Feature settings
@@ -194,3 +195,7 @@ Disabled
 ### 20/02/26 ([source](https://github.com/ministryofjustice/.github/pull/37))
 
 - Enable Google Gemini 3.1 Pro
+
+### 06/03/26 ([source](https://github.com/ministryofjustice/.github/pull/39))
+
+- Enable OpenAI GPT 5.4

--- a/docs/decisions/0001-enterprise-level-copilot-settings.md
+++ b/docs/decisions/0001-enterprise-level-copilot-settings.md
@@ -49,7 +49,7 @@ No pattern currently set
 | Anthropic Claude Opus 4.6 (fast mode) | Let organisations decide | Enabled                                  |
 | Google Gemini 2.5 Pro                 | Let organisations decide | Enabled                                  |
 | Google Gemini 3 Pro (Preview)         | Let organisations decide | Enabled                                  |
-| Google Gemini 3.1 Pro                 | Let organisations decide | Enabled                                  |
+| Google Gemini 3.1 Pro (Preview)       | Let organisations decide | Enabled                                  |
 | Google Gemini 3 Flash (Preview)       | Let organisations decide | Enabled                                  |
 | OpenAI GPT-5                          | Let organisations decide | Enabled                                  |
 | OpenAI GPT-5-Codex (Preview)          | Let organisations decide | Enabled                                  |
@@ -196,6 +196,6 @@ Disabled
 
 - Enable Google Gemini 3.1 Pro
 
-### 06/03/26 ([source](https://github.com/ministryofjustice/.github/pull/39))
+### 06/03/26 ([source](https://github.com/ministryofjustice/.github/pull/38))
 
 - Enable OpenAI GPT 5.4


### PR DESCRIPTION
## Proposed Changes

- Enables OpenAI GPT 5.4 model in enterprise level settings.
- Updates documentation to reflect the availability of GPT 5.4 for organisations within the enterprise.