### PR TITLE
:copilot: Enterprise AI Controls ADR

### DIFF
--- a/docs/decisions/0001-enterprise-level-copilot-settings.md
+++ b/docs/decisions/0001-enterprise-level-copilot-settings.md
@@ -1,11 +1,12 @@
 # 1. Initial configuration of enterprise level copilot settings
 
 Date: 2025-09-12
-Last Updated: 2026-05-29
+
+Last Updated: 2026-06-18
 
 ## Status
 
-Accepted
+Superseded by [0002](./0002-enterprise-ai-controls.md)
 
 ## Context
 

--- a/docs/decisions/0002-enterprise-ai-controls.md
+++ b/docs/decisions/0002-enterprise-ai-controls.md
@@ -42,19 +42,19 @@ _Selected Copilot models are available across every organization in Ministry of 
 
 | Model                                           | Status   |
 | ----------------------------------------------- | -------- |
-| Anthropic Claude Opus 4.5                       | Optional |
-| Anthropic Claude Sonnet 4.5                     | Optional |
 | Anthropic Claude Haiku 4.5                      | Optional |
-| Google Gemini 2.5 Pro                           | Optional |
-| Google Gemini 3 Flash (Preview)                 | Optional |
-| OpenAI GPT-5 mini                               | Optional |
+| Anthropic Claude Opus 4.5                       | Optional |
 | Anthropic Claude Opus 4.6                       | Optional |
 | Anthropic Claude Opus 4.6 (fast mode) (Preview) | Optional |
 | Anthropic Claude Opus 4.7                       | Optional |
 | Anthropic Claude Opus 4.8                       | Optional |
+| Anthropic Claude Sonnet 4.5                     | Optional |
 | Anthropic Claude Sonnet 4.6                     | Optional |
+| Google Gemini 2.5 Pro                           | Optional |
 | Google Gemini 3.1 Pro (Preview)                 | Optional |
 | Google Gemini 3.5 Flash                         | Optional |
+| Google Gemini 3 Flash (Preview)                 | Optional |
+| OpenAI GPT-5 mini                               | Optional |
 | OpenAI GPT-5.4                                  | Optional |
 | OpenAI GPT-5.4 mini                             | Optional |
 | OpenAI GPT-5.5                                  | Optional |

--- a/docs/decisions/0002-enterprise-ai-controls.md
+++ b/docs/decisions/0002-enterprise-ai-controls.md
@@ -1,0 +1,278 @@
+# 2. GitHub Copilot Enterprise AI Controls
+
+Date: 2026-06-18
+
+Last Updated: 2026-06-18
+
+## Status
+
+Proposed
+
+## Context
+
+This ADR is a enhancement of the previous ADR [0001](./0001-enterprise-level-copilot-settings.md).
+
+GitHub Copilot Enterprise has been contiously improving, and various new features have been added, as well as some existing features have been deprecated. This ADR aims to provide a comprehensive overview of the current state of GitHub Copilot Enterprise settings, including the new features and changes that have been introduced since the previous ADR.
+
+---
+
+## Key roles and responsibilities
+
+| Role                        | Description                                                                                                                                         | Owner/Team                |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| Project Responsible Owner   | Accountable for the system's proper development, compliance, and performance.                                                                       | Rosie Brigham             |
+| Technical Lead              | Responsible for procurement evaluation, integration, configuration, and ongoing technical oversight.                                                | Developer Experience Team |
+| Risk and Compliance Officer | Conducts risk and impact assessments, determines appropriate levels of human oversight, and ensures adherence to this framework for all AI systems. | Rosie Brigham             |
+
+---
+
+## Access management
+
+Access to GitHub Copilot is delegated to business units. They are responsible for managing access using GitHub Teams. This is done at an Organisation level.
+
+## Content Exclusion
+
+GitHub Copilot context exclusion is delegated to repository owners. They are responsible for managing content exclusion using the GitHub Copilot settings in their repositories. This is done at a repository level.
+
+## Allowed models
+
+### Default models
+
+_Selected Copilot models are available across every organization in Ministry of Justice (UK)_
+
+| Model                                           | Status   |
+| ----------------------------------------------- | -------- |
+| Anthropic Claude Opus 4.5                       | Optional |
+| Anthropic Claude Sonnet 4.5                     | Optional |
+| Anthropic Claude Haiku 4.5                      | Optional |
+| Google Gemini 2.5 Pro                           | Optional |
+| Google Gemini 3 Flash (Preview)                 | Optional |
+| OpenAI GPT-5 mini                               | Optional |
+| Anthropic Claude Opus 4.6                       | Optional |
+| Anthropic Claude Opus 4.6 (fast mode) (Preview) | Optional |
+| Anthropic Claude Opus 4.7                       | Optional |
+| Anthropic Claude Opus 4.8                       | Optional |
+| Anthropic Claude Sonnet 4.6                     | Optional |
+| Google Gemini 3.1 Pro (Preview)                 | Optional |
+| Google Gemini 3.5 Flash                         | Optional |
+| OpenAI GPT-5.4                                  | Optional |
+| OpenAI GPT-5.4 mini                             | Optional |
+| OpenAI GPT-5.5                                  | Optional |
+
+## Privacy
+
+### Suggestions matching public code
+
+_GitHub Copilot can allow or block [code suggestions](https://docs.github.com/en/copilot/using-github-copilot/finding-public-code-that-matches-github-copilot-suggestions) matching public code._
+
+Status: Blocked
+
+Rationale: TODO
+
+## Features
+
+### Policies for enterprise-assigned users
+
+_Enable all Copilot features set to "Let organizations decide" for users with a Copilot license assigned directly from the enterprise._
+
+Status: Disabled everywhere
+
+Rationale: We do not use enterprise-assigned users, so this setting is not applicable to us.
+
+### Spark (Preview)
+
+_Organizations can have access to [GitHub Spark](https://gh.io/responsible-use-of-github-spark). This preview is governed by GitHub's [pre-release terms](https://docs.github.com/en/site-policy/github-terms/github-pre-release-license-terms)._
+
+Status: Disabled everywhere
+
+Rationale: GitHub Spark functionality has not been evaluated yet, and we do not have a use case for it at this time.
+
+### Editor preview features
+
+_Organizations can have access to editor preview features._
+
+Status: Disabled everywhere
+
+Rationale: TODO
+
+### Copilot can search the web
+
+_Copilot can answer questions about new trends and give improved answers, via Bing. See [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement)._
+
+Status: Disabled everywhere
+
+Rationale: TODO
+
+### Copilot can search the web using model native search (Preview)
+
+_If enabled, Copilot can answer questions using a model's built-in search capabilities._
+
+Status: Disabled everywhere
+
+Rationale: TODO
+
+### Copilot-generated commit messages
+
+_If enabled, Copilot will [suggest commit messages](https://docs.github.com/en/copilot/responsible-use/copilot-commit-message-generation) for changes made on GitHub.com._
+
+Status: Disabled everywhere
+
+Rationale: TODO
+
+### Copilot Spaces
+
+_If enabled, organization members can view and create [Copilot Spaces](https://docs.github.com/en/copilot/how-tos/provide-context/use-copilot-spaces). When disabled, users cannot view or create any Copilot Spaces._
+
+Status: Let organizations decide
+
+Rationale: TODO
+
+### Copilot Spaces Individual Access
+
+_If enabled, organization members can create individually owned Copilot Spaces. When disabled, users cannot create individual spaces._
+
+Status: Disabled everywhere
+
+Rationale: TODO
+
+### Copilot Spaces Individual Sharing
+
+_If enabled, organization members can share individually owned Copilot Spaces that do not contain enterprise data. When disabled, users cannot share individual spaces._
+
+Status: Disabled everywhere
+
+Rationale: TODO
+
+### Copilot Memory (Preview)
+
+_Members can use [Copilot Memory](https://docs.github.com/copilot/concepts/agents/copilot-memory) to store facts about repositories and personal preferences about how they want to interact with Copilot. These are available to agents in future sessions. Users can turn this off at any time, regardless of enterprise or organization policy. Learn more in the [Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement). This preview is governed by [GitHub's pre-release terms](https://docs.github.com/en/site-policy/github-terms/github-pre-release-license-terms)._
+
+Status: Disabled everywhere
+
+Rationale: TODO
+
+### Semantic indexing for Non-GitHub Repositories (Preview)
+
+_If enabled, members of this business will have access to upload non-GitHub repositories for semantic indexing._
+
+Status: Disabled everywhere
+
+Rationale: TODO
+
+### Enable custom models (Preview)
+
+_Enable to allow your organizations to configure and use custom models via API key. When using custom models, GitHub is allowed to share your data with third-party services, including Azure and OpenAI, using your provided key._
+
+Status: Disabled
+
+Rationale: TODO
+
+### Bring Your Own Language Model Key in Select IDEs
+
+_Enable the use of your own third-party language model API keys for VS Code and JetBrains. [Learn more](https://code.visualstudio.com/docs/copilot/customization/language-models#_bring-your-own-language-model-key)._
+
+Status: Enabled everywhere
+
+Rationale: TODO
+
+## Billing
+
+### AI credit paid usage
+
+_If enabled, all organizations in your enterprise will be billed for AI credit paid usage [Set a budget to control your maximum spend](https://github.com/enterprises/ministry-of-justice-uk/billing/budgets)._
+
+Status: Disabled
+
+## Metrics
+
+### Copilot metrics API
+
+_If enabled, enterprise and organization administrators can query the [Copilot metrics API](https://docs.github.com/en/rest/copilot/copilot-metrics?apiVersion=2022-11-28) for insights into Copilot usage._
+
+Status: Disabled everywhere
+
+### Copilot usage metrics
+
+_If enabled, enterprise admins, billing managers, and authorized users can view Copilot usage metrics in a [dashboard](https://docs.github.com/en/copilot/concepts/copilot-metrics) and access the [Copilot Usage API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics?apiVersion=2022-11-28#get-copilot-enterprise-usage-metrics-for-a-specific-day)._
+
+Status: Enabled everywhere
+
+## Copilot clients
+
+### Copilot in GitHub.com
+
+_Organizations can use Copilot Chat in GitHub.com and knowledge base search._
+
+Status: Let organizations decide
+
+Rationale: TODO
+
+### Copilot CLI
+
+_Organizations can use GitHub Copilot for assistance in terminal._
+
+Status: Enabled everywhere
+
+### Store local sessions in the Cloud
+
+_Control how CLI and VS Code sessions are stored and accessed from the cloud._
+
+Status: Select a policy (effectively disabled)
+
+### Copilot in GitHub Desktop
+
+_Organizations can use GitHub Copilot for assistance in GitHub Desktop._
+
+Status: Disabled everywhere
+
+### Copilot Chat in GitHub Mobile
+
+_If enabled, organizations can use GitHub Copilot Chat in GitHub Mobile personalized to a codebase._
+
+Status: Disabled everywhere
+
+### Copilot Agent Mode in IDE Chat
+
+_If enabled, organizations may use Agent Mode within their IDE to interact with Copilot for the purpose of reasoning through requests, planning tasks, and making changes to the codebase. [Learn more](https://docs.github.com/en/copilot/how-tos/chat-with-copilot/chat-in-ide?tool=visualstudio#using-agent-mode-1)._
+
+Status: Enabled everywhere
+
+### Agent apps (Preview)
+
+_If enabled, enterprise admins can turn on agentic features provided by GitHub Apps._
+
+Status: Disabled everywhere
+
+## MCP
+
+### MCP servers in Copilot
+
+_Users can configure Model Context Protocol (MCP) servers for Copilot in all Copilot editors and Copilot cloud agent. See MCP docs for [Copilot Chat](https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-chat-with-mcp) and [Copilot cloud agent](https://docs.github.com/en/copilot/customizing-copilot/extending-copilot-coding-agent-with-mcp)._
+
+Status: Enabled everywhere
+
+## Agents
+
+### Copilot cloud agent
+
+_If enabled, users assigned a Copilot license from this enterprise will have access to Copilot cloud agent in repositories where it is enabled. This feature may use models which are not enabled on your "Models" settings page. [Learn more](https://gh.io/assigncopilot)._
+
+Status: Enabled for selected organizations
+
+### Block Copilot cloud agent in all repositories owned by Ministry of Justice (UK)
+
+_When enabled, Copilot cloud agent will be blocked from accessing all repositories owned by Ministry of Justice (UK), for all users—including those not managed by this enterprise._
+
+Status: Off
+
+### Copilot code review
+
+_If enabled, members who are licensed through organizations within this enterprise can use [Copilot code review](https://docs.github.com/en/enterprise-cloud@latest/copilot/using-github-copilot/code-review/using-copilot-code-review) and [Copilot for pull requests](https://docs.github.com/enterprise-cloud@latest/copilot/github-copilot-enterprise/copilot-pull-request-summaries/creating-a-pull-request-summary-with-github-copilot) in any repository they belong to._
+
+Status: Let organizations decide
+
+### Block Copilot code review in all enterprise repositories
+
+_If enabled, Copilot code review will be blocked in all repositories in this enterprise for all users, even if they are not assigned a Copilot license by this enterprise._
+
+Status: Off

--- a/docs/decisions/0002-enterprise-ai-controls.md
+++ b/docs/decisions/0002-enterprise-ai-controls.md
@@ -14,6 +14,10 @@ This ADR is an enhancement of the previous ADR [0001](./0001-enterprise-level-co
 
 GitHub Copilot Enterprise has been continuously improving, with new features added and some existing features deprecated. This ADR provides an overview of the current GitHub Copilot Enterprise settings, including features and changes introduced since ADR 0001.
 
+This ADR is intended to be both a governance record (what settings are in place and why) and a current-state reference.
+
+Controls documented in ADR 0001 that are no longer present in current enterprise settings are intentionally omitted from this document.
+
 ---
 
 ## Key roles and responsibilities
@@ -39,6 +43,8 @@ GitHub Copilot context exclusion is delegated to repository owners. They are res
 ### Default models
 
 _Selected Copilot models are available across every organization in Ministry of Justice (UK)_
+
+_Model status is documented at enterprise level. Copilot is enabled through one organization, so separate per-organization model variance is not tracked in this ADR._
 
 | Model                                           | Status   |
 | ----------------------------------------------- | -------- |
@@ -67,8 +73,6 @@ _GitHub Copilot can allow or block [code suggestions](https://docs.github.com/en
 
 Status: Blocked
 
-Rationale: TODO
-
 ## Features
 
 ### Policies for enterprise-assigned users
@@ -77,15 +81,11 @@ _Enable all Copilot features set to "Let organizations decide" for users with a 
 
 Status: Disabled everywhere
 
-Rationale: We do not use enterprise-assigned users, so this setting is not applicable to us.
-
 ### Spark (Preview)
 
 _Organizations can have access to [GitHub Spark](https://gh.io/responsible-use-of-github-spark). This preview is governed by GitHub's [pre-release terms](https://docs.github.com/en/site-policy/github-terms/github-pre-release-license-terms)._
 
 Status: Disabled everywhere
-
-Rationale: GitHub Spark functionality has not been evaluated yet, and we do not have a use case for it at this time.
 
 ### Editor preview features
 
@@ -93,15 +93,11 @@ _Organizations can have access to editor preview features._
 
 Status: Disabled everywhere
 
-Rationale: TODO
-
 ### Copilot can search the web
 
 _Copilot can answer questions about new trends and give improved answers, via Bing. See [Microsoft Privacy Statement](https://privacy.microsoft.com/en-us/privacystatement)._
 
 Status: Disabled everywhere
-
-Rationale: TODO
 
 ### Copilot can search the web using model native search (Preview)
 
@@ -109,15 +105,11 @@ _If enabled, Copilot can answer questions using a model's built-in search capabi
 
 Status: Disabled everywhere
 
-Rationale: TODO
-
 ### Copilot-generated commit messages
 
 _If enabled, Copilot will [suggest commit messages](https://docs.github.com/en/copilot/responsible-use/copilot-commit-message-generation) for changes made on GitHub.com._
 
 Status: Disabled everywhere
-
-Rationale: TODO
 
 ### Copilot Spaces
 
@@ -125,15 +117,11 @@ _If enabled, organization members can view and create [Copilot Spaces](https://d
 
 Status: Let organizations decide
 
-Rationale: TODO
-
 ### Copilot Spaces Individual Access
 
 _If enabled, organization members can create individually owned Copilot Spaces. When disabled, users cannot create individual spaces._
 
 Status: Disabled everywhere
-
-Rationale: TODO
 
 ### Copilot Spaces Individual Sharing
 
@@ -141,15 +129,11 @@ _If enabled, organization members can share individually owned Copilot Spaces th
 
 Status: Disabled everywhere
 
-Rationale: TODO
-
 ### Copilot Memory (Preview)
 
 _Members can use [Copilot Memory](https://docs.github.com/copilot/concepts/agents/copilot-memory) to store facts about repositories and personal preferences about how they want to interact with Copilot. These are available to agents in future sessions. Users can turn this off at any time, regardless of enterprise or organization policy. Learn more in the [Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement). This preview is governed by [GitHub's pre-release terms](https://docs.github.com/en/site-policy/github-terms/github-pre-release-license-terms)._
 
 Status: Disabled everywhere
-
-Rationale: TODO
 
 ### Semantic indexing for Non-GitHub Repositories (Preview)
 
@@ -157,23 +141,17 @@ _If enabled, members of this business will have access to upload non-GitHub repo
 
 Status: Disabled everywhere
 
-Rationale: TODO
-
 ### Enable custom models (Preview)
 
 _Enable to allow your organizations to configure and use custom models via API key. When using custom models, GitHub is allowed to share your data with third-party services, including Azure and OpenAI, using your provided key._
 
 Status: Disabled
 
-Rationale: TODO
-
 ### Bring Your Own Language Model Key in Select IDEs
 
 _Enable the use of your own third-party language model API keys for VS Code and JetBrains. [Learn more](https://code.visualstudio.com/docs/copilot/customization/language-models#_bring-your-own-language-model-key)._
 
 Status: Enabled everywhere
-
-Rationale: TODO
 
 ## Billing
 
@@ -204,8 +182,6 @@ Status: Enabled everywhere
 _Organizations can use Copilot Chat in GitHub.com and knowledge base search._
 
 Status: Let organizations decide
-
-Rationale: TODO
 
 ### Copilot CLI
 
@@ -276,3 +252,10 @@ Status: Let organizations decide
 _If enabled, Copilot code review will be blocked in all repositories in this enterprise for all users, even if they are not assigned a Copilot license by this enterprise._
 
 Status: Off
+
+## Amendments
+
+### 18/06/2026
+
+- Created ADR 0002 to supersede ADR 0001 and document the current enterprise AI control set.
+- Updated structure to reflect current GitHub Copilot Enterprise settings and feature areas.

--- a/docs/decisions/0002-enterprise-ai-controls.md
+++ b/docs/decisions/0002-enterprise-ai-controls.md
@@ -10,9 +10,9 @@ Proposed
 
 ## Context
 
-This ADR is a enhancement of the previous ADR [0001](./0001-enterprise-level-copilot-settings.md).
+This ADR is an enhancement of the previous ADR [0001](./0001-enterprise-level-copilot-settings.md).
 
-GitHub Copilot Enterprise has been contiously improving, and various new features have been added, as well as some existing features have been deprecated. This ADR aims to provide a comprehensive overview of the current state of GitHub Copilot Enterprise settings, including the new features and changes that have been introduced since the previous ADR.
+GitHub Copilot Enterprise has been continuously improving, with new features added and some existing features deprecated. This ADR provides an overview of the current GitHub Copilot Enterprise settings, including features and changes introduced since ADR 0001.
 
 ---
 


### PR DESCRIPTION
## Proposed Changes

- Introduces ADR0002 which captures the current as-is state of our Enterprise AI controls
- Marks ADR0001 as superseded by ADR0002 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>