### PR TITLE
:copilot: Enable GitHub Copilot Editor Preview Features

### DIFF
--- a/docs/decisions/0002-enterprise-ai-controls.md
+++ b/docs/decisions/0002-enterprise-ai-controls.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-18
 
-Last Updated: 2026-06-18
+Last Updated: 2026-06-19
 
 ## Status
 
@@ -91,7 +91,7 @@ Status: Disabled everywhere
 
 _Organizations can have access to editor preview features._
 
-Status: Disabled everywhere
+Status: Enabled everywhere
 
 ### Copilot can search the web
 
@@ -259,3 +259,7 @@ Status: Off
 
 - Created ADR 0002 to supersede ADR 0001 and document the current enterprise AI control set.
 - Updated structure to reflect current GitHub Copilot Enterprise settings and feature areas.
+
+### 19/06/2026
+
+- Enable "Editor preview features"


### PR DESCRIPTION
## Proposed Changes

- Enabled "Editor Preview Features" which is required to allow image upload as per [GitHub's docs](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/chat-with-copilot/chat-in-ide#using-images-in-copilot-chat)

>If you're using a Copilot Business or Copilot Enterprise plan, the organization or enterprise that provides your plan must enable the Editor preview features setting. See [Managing policies and features for GitHub Copilot in your organization](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) or [Managing policies and features for GitHub Copilot in your enterprise](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-copilot-for-your-enterprise/managing-policies-and-features-for-copilot-in-your-enterprise#configuring-policies-for-github-copilot).

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>