### PR TITLE
Add org-level Octo STS trust policy for dora-the-explora

### DIFF
--- a/.github/chainguard/ministryofjustice-dora-the-explora.sts.yaml
+++ b/.github/chainguard/ministryofjustice-dora-the-explora.sts.yaml
@@ -1,0 +1,31 @@
+# Org-level Octo STS trust policy for ministryofjustice/dora-the-explora.
+#
+# dora-the-explora computes DORA metrics across the estate (per-team metrics,
+# Modernisation Platform Environments applications, and Cloud Platform tenants),
+# so its scheduled workflows must READ from many repositories owned by other
+# teams. Adding a per-repo trust policy to every one of those repos (the Cloud
+# Platform cohort alone is ~150 and changes over time) is not maintainable, so
+# this org-level policy lets dora-the-explora mint a short-lived, READ-ONLY
+# token across the org instead of holding a long-lived PAT.
+#
+# Scope decisions (see PR description for rationale):
+#   * subject_pattern is pinned to the main branch of dora-the-explora only, so
+#     pull requests and forks cannot mint a token.
+#   * permissions are read-only. The scopes cover every DORA workflow:
+#       - contents:      commits (lead time) and file reads (cohort enumeration)
+#       - deployments:   MPE/CP deployment-based metrics
+#       - actions:       workflow runs (change failure rate, deployment
+#                        frequency, MTTR in the per-team scripts)
+#       - pull_requests: merged PRs (lead time for change)
+#   * no `repositories:` allow-list: the token can read across all repositories
+#     the Octo STS installation can see. This is intentional because the metric
+#     cohorts are dynamic; the grant is read-only.
+---
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:ministryofjustice/dora-the-explora:ref:refs/heads/main
+
+permissions:
+  contents: read
+  deployments: read
+  actions: read
+  pull_requests: read


### PR DESCRIPTION
## What

Adds an org-level Octo STS trust policy at `.github/chainguard/ministryofjustice-dora-the-explora.sts.yaml`, allowing [`dora-the-explora`](https://github.com/ministryofjustice/dora-the-explora) to mint short-lived, read-only tokens across the org via OIDC.

(Replaces #52, which was closed after a branch mishap; the commit here is signed/verified.)

## Why

`dora-the-explora` computes DORA metrics across the estate — per-team metrics, Modernisation Platform Environments applications, and Cloud Platform tenants. Its scheduled workflows must **read** from many repositories owned by other teams (the CP cohort alone is ~150 and changes over time), so a per-repo trust policy on every repo is not maintainable. This org-level policy lets those workflows drop the long-lived `DATA_PLATFORM_ROBOT_PAT` in favour of ephemeral, auto-expiring tokens.

`scope: ministryofjustice` (a bare org name) resolves to this org-level policy — confirmed against the octo-sts source (`path.Dir(scope) == "."` → reads `<org>/.github`).

## Scope & safety

- **Pinned to main:** `subject_pattern: repo:ministryofjustice/dora-the-explora:ref:refs/heads/main` — only scheduled runs on `main` can mint; PRs/forks cannot.
- **Read-only, four scopes:** `contents`, `deployments`, `actions`, `pull_requests` read — covers all DORA workflows (deployments for MPE/CP, actions for workflow-run metrics, pull_requests + contents for lead time).
- **No `repositories:` allow-list** → org-wide read. Intentional (dynamic cohorts); grant is read-only. Can be narrowed to an allow-list if preferred, at the cost of periodic regeneration.

## Blast radius

Concentrates org-wide **read** in one repo; anyone able to run the trusted (main-branch) workflow effectively has org-wide read via those scopes. Pinning the subject to `main` keeps PRs/forks out.

## Consumer

Paired with ministryofjustice/dora-the-explora#277, which converts the three DORA workflows to consume this via `octo-sts/action`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)